### PR TITLE
Improve error reporting + add an option to avoid checking certificates base (only) on known CA.

### DIFF
--- a/ba-simple-proxy.php
+++ b/ba-simple-proxy.php
@@ -181,9 +181,16 @@ if ( !$url ) {
   curl_setopt( $ch, CURLOPT_HEADER, true );
   curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
   
-  curl_setopt( $ch, CURLOPT_USERAGENT, $_GET['user_agent'] ? $_GET['user_agent'] : $_SERVER['HTTP_USER_AGENT'] );
+  // in case you wish Not to confirm the CA for your server (e.g. it's inside your org)
+  // curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER , false);
   
-  list( $header, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', curl_exec( $ch ), 2 );
+  curl_setopt( $ch, CURLOPT_USERAGENT, $_GET['user_agent'] ? $_GET['user_agent'] : $_SERVER['HTTP_USER_AGENT'] );
+  $res = curl_exec( $ch );
+  if ($res === FALSE) {
+    // in case we have errors - let's report them!
+    die(curl_error($ch));
+  }
+  list( $header, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', $res, 2 );
   
   $status = curl_getinfo( $ch );
   


### PR DESCRIPTION
1. Report errors in cUrl.
2. Add a comment with an option (I've used many times) to Not verify SSL certificates. It's good option for internal usage.
