### PR TITLE
Do not fail on HTTP 100 Response

### DIFF
--- a/ba-simple-proxy.php
+++ b/ba-simple-proxy.php
@@ -185,6 +185,10 @@ if ( !$url ) {
   
   list( $header, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', curl_exec( $ch ), 2 );
   
+  if($header == 'HTTP/1.1 100 Continue') {
+    list($header, $contents) = preg_split( '/([\r\n][\r\n])\\1/', $contents, 2 );
+  }
+
   $status = curl_getinfo( $ch );
   
   curl_close( $ch );


### PR DESCRIPTION
Because of the way the headers are split the proxy will fail if the server sends a 100 Continue response because sending the data. This pull request fixes that.
