### PR TITLE
fixes #1 on cowboy/php-simple-proxy

### DIFF
--- a/ba-simple-proxy.php
+++ b/ba-simple-proxy.php
@@ -163,8 +163,8 @@ if ( !$url ) {
     curl_setopt( $ch, CURLOPT_POST, true );
     curl_setopt( $ch, CURLOPT_POSTFIELDS, $_POST );
   }
-  
-  if ( $_GET['send_cookies'] ) {
+
+  if ( array_key_exists('send_cookies', $_GET) ) {
     $cookie = array();
     foreach ( $_COOKIE as $key => $value ) {
       $cookie[] = $key . '=' . $value;
@@ -180,9 +180,9 @@ if ( !$url ) {
   curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
   curl_setopt( $ch, CURLOPT_HEADER, true );
   curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-  
-  curl_setopt( $ch, CURLOPT_USERAGENT, $_GET['user_agent'] ? $_GET['user_agent'] : $_SERVER['HTTP_USER_AGENT'] );
-  
+
+  curl_setopt( $ch, CURLOPT_USERAGENT, array_key_exists('user_agent', $_GET) ? $_GET['user_agent'] : $_SERVER['HTTP_USER_AGENT'] );
+
   list( $header, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', curl_exec( $ch ), 2 );
   
   $status = curl_getinfo( $ch );
@@ -193,7 +193,7 @@ if ( !$url ) {
 // Split header text into an array.
 $header_text = preg_split( '/[\r\n]+/', $header );
 
-if ( $_GET['mode'] == 'native' ) {
+if ( array_key_exists('mode', $_GET) && $_GET['mode'] == 'native' ) {
   if ( !$enable_native ) {
     $contents = 'ERROR: invalid mode';
     $status = array( 'http_code' => 'ERROR' );
@@ -214,7 +214,7 @@ if ( $_GET['mode'] == 'native' ) {
   $data = array();
   
   // Propagate all HTTP headers into the JSON data object.
-  if ( $_GET['full_headers'] ) {
+  if ( array_key_exists('full_headers', $_GET) ) {
     $data['headers'] = array();
     
     foreach ( $header_text as $header ) {
@@ -226,7 +226,7 @@ if ( $_GET['mode'] == 'native' ) {
   }
   
   // Propagate all cURL request / response info to the JSON data object.
-  if ( $_GET['full_status'] ) {
+  if ( array_key_exists('full_status', $_GET) ) {
     $data['status'] = $status;
   } else {
     $data['status'] = array();


### PR DESCRIPTION
Fix all UNDEFINED notices so they don't trigger when error reporting turned on.
This is done by using `array_key_exists` instead of directly accessing the array index (that could be undefined)
